### PR TITLE
Add enabled config

### DIFF
--- a/config/twilio-notification-channel.php
+++ b/config/twilio-notification-channel.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'enabled' => env('TWILIO_ENABLED', true),
     'username' => env('TWILIO_USERNAME'), // optional when using auth token
     'password' => env('TWILIO_PASSWORD'), // optional when using auth token
     'auth_token' => env('TWILIO_AUTH_TOKEN'), // optional when using username and password

--- a/src/TwilioChannel.php
+++ b/src/TwilioChannel.php
@@ -82,7 +82,7 @@ class TwilioChannel
     /**
      * Check if twilio is enabled.
      *
-     * @return boolean
+     * @return bool
      */
     protected function isEnabled()
     {

--- a/src/TwilioChannel.php
+++ b/src/TwilioChannel.php
@@ -43,7 +43,7 @@ class TwilioChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (! $this->twilio->config->enabled()) {
+        if (! $this->isEnabled()) {
             return;
         }
 
@@ -77,6 +77,20 @@ class TwilioChannel
 
             throw $exception;
         }
+    }
+
+    /**
+     * Check if twilio is enabled.
+     *
+     * @return boolean
+     */
+    protected function isEnabled()
+    {
+        if (is_null($this->twilio->config)) {
+            return true;
+        }
+
+        return $this->twilio->config->enabled();
     }
 
     /**

--- a/src/TwilioChannel.php
+++ b/src/TwilioChannel.php
@@ -43,6 +43,10 @@ class TwilioChannel
      */
     public function send($notifiable, Notification $notification)
     {
+        if (! $this->twilio->config->enabled()) {
+            return;
+        }
+
         try {
             $to = $this->getTo($notifiable, $notification);
             $message = $notification->toTwilio($notifiable);

--- a/src/TwilioConfig.php
+++ b/src/TwilioConfig.php
@@ -17,7 +17,7 @@ class TwilioConfig
 
     public function enabled()
     {
-        return $this->config['enabled'];
+        return $this->config['enabled'] ?? true;
     }
 
     public function usingUsernamePasswordAuth(): bool

--- a/src/TwilioConfig.php
+++ b/src/TwilioConfig.php
@@ -15,6 +15,11 @@ class TwilioConfig
         $this->config = $config;
     }
 
+    public function enabled()
+    {
+        return $this->config['enabled'];
+    }
+
     public function usingUsernamePasswordAuth(): bool
     {
         return $this->getUsername() !== null && $this->getPassword() !== null && $this->getAccountSid() !== null;

--- a/tests/Integration/BaseIntegrationTest.php
+++ b/tests/Integration/BaseIntegrationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NotificationChannels\Twilio\Tests\Integration;
 
 use NotificationChannels\Twilio\TwilioProvider;
-use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\TestCase;
 
 abstract class BaseIntegrationTest extends TestCase
 {

--- a/tests/Unit/TwilioChannelTest.php
+++ b/tests/Unit/TwilioChannelTest.php
@@ -37,6 +37,21 @@ class TwilioChannelTest extends MockeryTestCase
     }
 
     /** @test */
+    public function it_will_not_send_a_message_if_not_enabled()
+    {
+        $notifiable = new Notifiable();
+        $notification = Mockery::mock(Notification::class);
+
+        $this->twilio->config = new TwilioConfig([
+            'enabled' => false,
+        ]);
+
+        $result = $this->channel->send($notifiable, $notification);
+
+        $this->assertNull($result);
+    }
+
+    /** @test */
     public function it_will_not_send_a_message_without_known_receiver()
     {
         $notifiable = new Notifiable();

--- a/tests/Unit/TwilioChannelTest.php
+++ b/tests/Unit/TwilioChannelTest.php
@@ -46,6 +46,8 @@ class TwilioChannelTest extends MockeryTestCase
             'enabled' => false,
         ]);
 
+        $this->dispatcher->shouldNotReceive('dispatch');
+
         $result = $this->channel->send($notifiable, $notification);
 
         $this->assertNull($result);


### PR DESCRIPTION
@ajcastro's original https://github.com/laravel-notification-channels/twilio/pull/121

> This resolves issue https://github.com/laravel-notification-channels/twilio/issues/120 . This lets us explicitly enable/disable sending twilio sms.